### PR TITLE
Run files independently by default

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -69,13 +69,13 @@ def run_pipeline(
     for file in files:
         success = dispatcher.dispatch(file)  # Automatically catches and logs exceptions
         if success:
-            logger.info("Successfully processed file '%s'", Path(file).name)
+            logger.info("Successfully processed input: '%s'", file)
             successes += 1
         else:
-            logger.warning("Failed to process file: '%s'", Path(file).name)
+            logger.warning("Failed to process input: '%s'", file)
             failures += 1
 
-    logger.info("Done! (%d successes, %d failures)", successes, failures)
+    logger.info("Done! (%d succeeded, %d failed)", successes, failures)
 
 
 if __name__ == "__main__":

--- a/runner.py
+++ b/runner.py
@@ -1,10 +1,10 @@
 import typer
+import logging
 
 from typing import List
 from pathlib import Path
 from enum import Enum
 from utils import (
-    logger,
     PipelineDispatcher,
     set_dev_env,
     set_prod_env,
@@ -12,9 +12,9 @@ from utils import (
 
 
 # TODO: Examine logging more closely –  can this be improved?
+logger = logging.getLogger(__name__)
 
-
-app = typer.Typer()
+app = typer.Typer(add_completion=False)
 
 
 class Mode(str, Enum):
@@ -34,34 +34,52 @@ def run_pipeline(
         help="Path(s) to the file(s) to process",
     ),
     mode: Mode = typer.Option(Mode.local, help="The processing mode to use."),
+    clump: bool = typer.Option(
+        False,
+        help="Clump all the files together to be run by a single ingest. This typically"
+        " results in one output data file being produced. Omit this option to run files"
+        " independently (the default) and generally produce one output data file for"
+        " every input file.",
+    ),
 ):
-    """
-    Main entry point to the ingest controller. This script takes a path to an input
-    file, automatically determines which ingest(s) to use, and runs those ingests
-    on the provided input data.
+    """Main entry point to the ingest controller. This script takes a path to an input
+    file, automatically determines which ingest(s) to use, and runs those ingests on the
+    provided input data."""
 
-    Args:
-        input_file (str): The path to the input file to process.
-        mode (str, optional): The processing mode used.
+    # Downstream code expects a list of strings
+    files: List[str] = [str(file) for file in files]
+    logger.debug(f"Found input files: {files}")
 
-    """
+    if clump:
+        files = [files]
 
-    logger.debug(f"Using [{mode.value}] mode to run the follow file:\n{files}")
+    # Configure settings / environment variables
     if mode.value == Mode.local:
         set_dev_env()
     elif mode == Mode.aws:
         set_prod_env()
+    logger.debug(f"Using mode: '{mode.value}'")
 
-    logger.info(f"Found input files: {files}")
-
+    # Run the pipeline on the input files
     dispatcher = PipelineDispatcher(auto_discover=True)
-
     logger.debug(f"Discovered ingest modules: \n{dispatcher._cache._modules}")
 
-    success = dispatcher.dispatch(files)
+    successes = 0
+    failures = 0
+    for file in files:
+        success = dispatcher.dispatch(file)  # Automatically catches and logs exceptions
+        if success:
+            logger.info("Successfully processed file '%s'", Path(file).name)
+            successes += 1
+        else:
+            logger.warning("Failed to process file: '%s'", Path(file).name)
+            failures += 1
 
-    logger.info(f"Pipeline status: {'success' if success else 'failure'}")
+    logger.info("Done! (%d successes, %d failures)", successes, failures)
 
 
 if __name__ == "__main__":
-    typer.run(run_pipeline)
+    logging.basicConfig(level=logging.INFO)
+    logger.setLevel(level=logging.INFO)
+
+    app()

--- a/utils/dispatcher.py
+++ b/utils/dispatcher.py
@@ -2,9 +2,13 @@
 # method (Pipeline.run(...) vs Pipeline.run_plots(...)) based on mapping – if "plots"
 # is part of the IngestSpec.name string then dispatch to _run_plots()
 
+import logging
 from tsdat.io import S3Path
 from typing import List, Union
 from .cache import PipelineCache
+
+
+logger = logging.getLogger(__name__)
 
 
 class PipelineDispatcher:
@@ -27,15 +31,10 @@ class PipelineDispatcher:
             error, False otherwise.
 
         ----------------------------------------------------------------------------"""
+        if not isinstance(input_files, List):
+            input_files = [input_files]
 
-        specification = self._cache.match_filepath(input_files)
-
-        if "plot" in specification.name:
-            return self._run_plots(input_files)
-
-        return self._run_pipeline(input_files)
-
-    def _run_pipeline(self, input_files: Union[List[S3Path], List[str]]) -> bool:
+        status = True
 
         # TODO: Catch possible exceptions:
         # AssertionError – no regex match, or too many matches`
@@ -43,24 +42,15 @@ class PipelineDispatcher:
         # DefinitionError – a config file not defined correctly.
         # QCError – pipeline failed because of poor data quality – manual intervention
         # BaseException – any other error: catch, report, and carry on.
+        try:
+            specification = self._cache.match_filepath(input_files)
+            pipeline = specification.instantiate()
+            if "plot" in specification.name:
+                pipeline.run_plots(input_files)
+            else:
+                pipeline.run(input_files)
+        except BaseException:
+            logger.exception("Pipeline failed on input files: %s", input_files)
+            status = False
 
-        specification = self._cache.match_filepath(input_files)
-        pipeline = specification.instantiate()
-        pipeline.run(input_files)
-
-        return False  # Not Implemented
-
-    def _run_plots(self, input_files: Union[List[S3Path], List[str]]) -> bool:
-
-        # TODO: Catch possible exceptions:
-        # AssertionError – no regex match, or too many matches
-        # FileNotFoundError – bad config file path or data file path
-        # DefinitionError – a config file not defined correctly.
-        # QCError – pipeline failed because of poor data quality – manual intervention
-        # BaseException – any other error: catch, report, and carry on.
-
-        specification = self._cache.match_filepath(input_files)
-        pipeline = specification.instantiate()
-        pipeline.run_plots(input_files)
-
-        return False  # Not Implemented
+        return status


### PR DESCRIPTION
This PR changes the runner functionality such that input files will be processed independently if multiple are provided at once via the CLI (e.g., by using a glob pattern) instead of ingesting all the files together in the same ingest and producing 1 output file. I added an optional `--clump` flag to the CLI which causes the script to use the original behavior. `--no-clump` can also be used to explicitly declare that the files should be processed independently, but this is not needed.

Also included some basic logging improvements and better error handling.

