### PR TITLE
Broaden allowable scan types

### DIFF
--- a/ingest/lidar_halo_xrp_nwtc/pipeline/pipeline.py
+++ b/ingest/lidar_halo_xrp_nwtc/pipeline/pipeline.py
@@ -50,7 +50,7 @@ class LidarHaloXrpPipeline(A2ePipeline):
                 z_id = str(dataset.attrs["System ID"])
                 scan_type = ""
                 if "user" in raw_basename.lower():
-                    scan_type = "user"
+                    scan_type = raw_basename.split('_')[0].lower()
                 elif "stare" in raw_basename.lower():
                     scan_type = "stare"
                 elif "vad" in raw_basename.lower():

--- a/ingest/lidar_halo_xrp_nwtc/pipeline/pipeline.py
+++ b/ingest/lidar_halo_xrp_nwtc/pipeline/pipeline.py
@@ -60,7 +60,8 @@ class LidarHaloXrpPipeline(A2ePipeline):
 
         qualifier = self.config.pipeline_definition.qualifier
 
-        if scan_type not in ["user", "stare", "vad", "wind_profile"]:
+        valid_types = ["user", "stare", "vad", "wind_profile"]
+        if not any(valid_type in scan_type for valid_type in valid_types):
             raise NameError(f"Scan type '{scan_type}' not supported.")
 
         new_qualifier = "_".join([qualifier, scan_type, z_id])


### PR DESCRIPTION
This PR broadens the allowable scan types, fixing a bug that was introduced in #21.
