### PR TITLE
added pipeline config for UTD halo (C1a)

### DIFF
--- a/pipelines/lidar_halo_xrp/config/pipeline_sc1.yaml
+++ b/pipelines/lidar_halo_xrp/config/pipeline_sc1.yaml
@@ -1,0 +1,23 @@
+classname: pipelines.lidar_halo_xrp.pipeline.LidarHaloXrp
+
+triggers:
+  - .*sc1\.lidar\.z01\.00.*\.hpl
+
+retriever:
+  path: pipelines/lidar_halo_xrp/config/retriever.yaml
+
+dataset:
+  path: pipelines/lidar_halo_xrp/config/dataset.yaml
+  overrides:
+    /attrs/description: AWAKEN XR Halo Lidar data
+    /attrs/qualifier: halo_xr
+    /attrs/location_id: sc1
+    /attrs/location_meaning: "Site C1a"
+    /attrs/dataset_name: lidar_z01
+    /data_vars/longitude/data: -97.510022
+    /data_vars/latitude/data: 36.361602
+
+quality:
+  path: shared/quality.yaml
+storage:
+  path: shared/storage.yaml


### PR DESCRIPTION
Added pipeline config for UTD Halo XR (C1a). It uses the halo_xrp pipeline, although the lidar is a Halo XR. The ingest works fine, just changed the lidar model and location in the pipeline.yaml